### PR TITLE
Add ID filter to Vehicle API

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -16,7 +16,7 @@ class VehicleFilter(FilterSet):
 
     class Meta:
         model = Vehicle
-        fields = ['operator', 'vehicle_type', 'livery', 'withdrawn', 'reg', 'fleet_code']
+        fields = ['id', 'operator', 'vehicle_type', 'livery', 'withdrawn', 'reg', 'fleet_code']
 
 
 class VehicleViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Add an extra filter to the Vehicle API of ID. This has advantages of:
- The ability to look up the vehicle when the ID is the only thing known
- The ability to update data based on the previously saved ID so a lookup is not required again