### PR TITLE
Added Link Network BODS. Removed Lakeside BODS

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -498,7 +498,7 @@ BOD_OPERATORS = [
         'GO': 'GOCH'
     }, False),
 
-    ('LAKC', 'WM', {}, False),
+    # ('LAKC', 'WM', {}, False),
 
     ('CBBH', 'EM', {
         'CBBH': 'CBBH',
@@ -546,6 +546,8 @@ BOD_OPERATORS = [
     ('LUCK', 'SW', {}, False),
     
     ('GVTR', 'NE', {}, False),
+    ('LNNE', 'NW', {}, False),
+
     
     ('RDRT', 'SE', {
         'RR': 'RDRT',


### PR DESCRIPTION
Lakeside BODS is wrong because they have it all on different datasets and for some reason, at least 2 routes are missing. The Whitchurch Circular bus and Ellesmere to Shrewsbury.

Link Network BODS added because there are schools missing on the Traveline timetable.