### PR TITLE
Add full docker-compose startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+.git/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ busstops/static/css/*.css.map
 .env
 .coverage
 slim-bustimes.sql
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.9-buster
 
-RUN apt-get update && apt-get install -y gdal-bin
+RUN apt-get update && apt-get install -y gdal-bin npm
 
 RUN pip install poetry
 
 WORKDIR /app/
 COPY poetry.lock pyproject.toml /app/
 RUN poetry install
+
+COPY package.json package-lock.json /app/
+RUN npm install

--- a/README.md
+++ b/README.md
@@ -23,14 +23,25 @@ This documentation is incomplete and out of date. And that's OK (?) because I do
 
 ## Installing
 
+### Using Docker
+
+You need Docker installed with docker-compose 1.27.0+. Then you can start the whole environment:
+
+```
+docker-compose up
+```
+
+### Using local install
+
 These need to be available:
 
-- Python 3.9
+- Python 3.9+
 - [Poetry](https://python-poetry.org/) to install necessary Python packages (Django, etc)
 - PostgreSQL with PostGIS
     - On my Macintosh computer I use [Postgres.app](https://postgresapp.com/)
 - `npm` to install some front end JavaScript things
-- Redis 6.2
+- Redis 6.2+
+- [GDAL](https://gdal.org/)
 
 Some environment variables need to be set.
 Many of them control settings in [buses/settings.py](buses/settings.py).
@@ -48,6 +59,16 @@ PGPASSWORD=password
 CELERY_BROKER_URL=redis://localhost:6379
 #AWS_ACCESS_KEY_ID=
 #AWS_SECRET_ACCESS_KEY=
+```
+
+Then run, preferably in a virtual environment, those commands:
+
+```
+npm install
+make build-static
+poetry install
+poetry run ./manage.py migrate
+poetry run ./manage.py runserver 0.0.0.0:8000 
 ```
 
 [.github/workflows/pythonapp.yml](.github/workflows/pythonapp.yml) sort of documents the process of installing dependencies and running tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     command: sh -c "make watch & poetry run ./manage.py migrate && poetry run ./manage.py runserver 0.0.0.0:8000"
     container_name: django_web
     environment:
-      - DEBUG=${SECRET_KEY-1}
+      - DEBUG=${DEBUG-1}
       - SECRET_KEY=${SECRET_KEY-d}
       - PGHOST=${PGHOST-postgres}
       - PGUSER=${PGUSER-postgres}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,43 @@
 services:
   web:
     build: .
-    command: poetry run ./manage.py runserver 0.0.0.0:8000
+    command: sh -c "make watch & poetry run ./manage.py migrate && poetry run ./manage.py runserver 0.0.0.0:8000"
     container_name: django_web
     environment:
       - DEBUG=1
       - SECRET_KEY=d
-      # I have Postgres and Redis running on the host machine outside of Docker
-      - PGHOST=host.docker.internal
-      - PGUSER=josh
-      - REDIS_URL=redis://host.docker.internal:6379
+      - PGHOST=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
+      - DB_NAME=postgres
+      - REDIS_URL=redis://redis:6379
     volumes:
       - .:/app
+      - node_modules:/app/node_modules
     ports:
       - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+  postgres:
+    image: postgis/postgis
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      interval: 3s
+      test: pg_isready -U $$POSTGRES_USER
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      interval: 3s
+      test: redis-cli ping
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     command: sh -c "make watch & poetry run ./manage.py migrate && poetry run ./manage.py runserver 0.0.0.0:8000"
     container_name: django_web
     environment:
-      - DEBUG=1
-      - SECRET_KEY=d
-      - PGHOST=postgres
-      - PGUSER=postgres
-      - PGPASSWORD=postgres
-      - DB_NAME=postgres
-      - REDIS_URL=redis://redis:6379
+      - DEBUG=${SECRET_KEY-1}
+      - SECRET_KEY=${SECRET_KEY-d}
+      - PGHOST=${PGHOST-postgres}
+      - PGUSER=${PGUSER-postgres}
+      - PGPASSWORD=${PGPASSWORD-postgres}
+      - DB_NAME=${DB_NAME-postgres}
+      - REDIS_URL=${REDIS_URL-redis://redis:6379}
     volumes:
       - .:/app
       - node_modules:/app/node_modules


### PR DESCRIPTION
I found it tricky to understand the whole process of bringing the environment up, so I figured it out and put it all in the `docker-compose`.

This should help others getting started on the project, and the existing workflow can remain if you define your own `.env` file (docker-compose will automatically pick that up).