### PR TITLE
Added MyTrip by Passenger websites for Open Data

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -336,6 +336,15 @@ PASSENGER_OPERATORS = [
     ('Newport Bus', 'https://www.newportbus.co.uk/open-data', 'W', {
         'NWPT': 'NWPT',
     }),
+    ('JMB Travel', 'https://www.jmbtravel.co.uk/open-data', 'S', {
+        'NJMT': 'NJMT',
+    }),
+    ('McColls Travel', 'https://www.mccolls.org.uk/open-data', 'S', {
+        'MCLS': 'MCLS',
+    }),
+    ('Redline', 'https://www.redlinebuses.com/open-data', 'SE', {
+        'RLNE': 'RLNE',
+    }),
 ]
 
 # see bustimes.management.commands.import_bod
@@ -701,7 +710,7 @@ TICKETER_OPERATORS = [
     ('EM', ['Brylaine', 'BRYL']),
     ('EM', ['Midland_Classic', 'MDCL']),
     ('EM', ['RBTS'], 'Roberts Travel'),
-    ('SE', ['Redline_Buses_Ltd', 'RLNE']),
+    # ('SE', ['Redline_Buses_Ltd', 'RLNE']),
     ('NW', ['HATT'], 'Hattons'),
     ('SE', ['Sullivan_Buses', 'SULV']),
     ('EA', ['Simonds', 'SIMO']),


### PR DESCRIPTION
Added JMB Travel, McColls Travel and Redline to this system using Passengers open data system. Redline is changed to use the Passenger Open Data versus the BODS open data since this should be more correct.