### PR TITLE
Added Merseyside Operators

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -628,6 +628,13 @@ BOD_OPERATORS = [
         'RR': 'RDRT',
         'RR1': 'RDRT'
     }, False),
+    
+    ('CUBU', 'NW', {}, False),
+    ('HUYT', 'NW', {}, False),
+    ('AJTX', 'NW', {}, False),
+    ('PPBU', 'NW', {}, False),
+    ('EAZI', 'NW', {}, False),
+    ('MAGH', 'NW', {}, False),
 ]
 
 # see bustimes.management.commands.import_bod


### PR DESCRIPTION
These Merseyside Operators have their BODS timetables sorted by Merseytravel (the PTE) so should all be correct and work.