### PR TITLE
Hattons is in twice

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -602,7 +602,7 @@ BOD_OPERATORS = [
     ('RBTS', 'EM', {}, False),
     ('DELA', 'EM', {}, False),
     ('RLNE', 'SE', {}, False),
-    ('HATT', 'NW', {}, False),
+    # ('HATT', 'NW', {}, False),
     ('SULV', 'SE', {}, False),
     ('WBSV', 'SE', {}, False),
     ('REDE', 'SE', {}, False),


### PR DESCRIPTION
Removing Hattons from normal BODS to see if the BODS or Ticketer datasets are best since two of the routes are messed up

https://bustimes.org/services/630-wigan-platt-bridge-via-ince
https://bustimes.org/services/613-top-lock-wigan

Duplicated times and the buses only run hourly so the times may be wrong.