### PR TITLE
Added Transdev Flyer & York & Country

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -322,6 +322,8 @@ PASSENGER_OPERATORS = [
         'HDT': 'HRGT',
         'YCD': 'YCST',
         'TPEN': 'TPEN',
+        'FLYE': 'FLYE',
+        'YACT': 'YACT',
     }),
     ('Go North East', 'https://www.gonortheast.co.uk/open-data', 'NE', {
         'GNE': 'GNEL',


### PR DESCRIPTION
Could this fix the issue of Flyer buses appearing under 'Transdev York' which is then leading to service duplication?
https://bustimes.org/services/a2-bradford-leeds-bradford-airport-harrogate (Transdev York from open data)
https://bustimes.org/services/a2-bradford-harrogate (Flyer from Traveline database)