### PR TITLE
Update settings.py

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -99,6 +99,7 @@ jobs:
 
     - name: Upload coverage
       # upload the Python coverage.py report to https://bustimes-coverage.ams3.digitaloceanspaces.com/index.html
+      continue-on-error: true
       env:
         AWS_EC2_METADATA_DISABLED: true
         AWS_ACCESS_KEY_ID: ${{ secrets.SPACE_ACCESS_KEY_ID }}

--- a/buses/settings.py
+++ b/buses/settings.py
@@ -409,6 +409,7 @@ BOD_OPERATORS = [
     ('HIPK', 'EM', {
         'OP': 'HIPK',
         'HPB': 'HIPK',
+    }, False),
     ('HNTS', 'EM', {}, False),
     # ('SLBS', 'WM', {}, True),
 
@@ -779,5 +780,5 @@ TICKETER_OPERATORS = [
     ('WM', ['DIAM'], 'Diamond Bus'),
     ('NW', ['GTRI'], 'Diamond Bus North West'),
     ('NW', ['PBLT'], 'Preston Bus'),
-    {'SE', ['WNGS'], 'Diamond South East'),
+    ('SE', ['WNGS'], 'Diamond South East'),
 ]

--- a/buses/settings.py
+++ b/buses/settings.py
@@ -518,27 +518,19 @@ BOD_OPERATORS = [
         'OURH': 'OURH',
         'OBUS': 'OBUS',
     }, False),
-
-    #('WNGS', None, {  # Rotala Group of Companies
-    #    'WINGS': 'WNGS',
-    #    'TGM': 'WNGS',  # Diamond SE
-    #    'NXHH': 'NXHH',  # Hotel Hoppa
-    #    'DIAM': 'DIAM',  # Diamond WM
-    #    'GTRI': 'GTRI',  # Diamond NW
-    #    'PBLT': 'PBLT',  # Preston
-    #}, False),
-
     ('PLNG', 'EA', {}, False),
     ('SNDR', 'EA', {}, False),
     ('AWAY', 'EA', {}, False),
-    ('COMM', 'EM', {}, False),
-    ('STOT', 'NW', {}, False),
-    ('CARL', 'SE', {}, False),
-    ('IRVD', 'NW', {}, False),
-    ('FALC', 'SE', {}, False),
-    ('VECT', 'SE', {}, True),
-    ('ACME', 'SE', {}, False),
-    # ('LTKR', 'SE', {}, False),
+
+    ('WNGS', None, {  # Rotala Group of Companies
+        'WINGS': 'WNGS',
+        'TGM': 'WNGS',  # Diamond SE
+        'NXHH': 'NXHH',  # Hotel Hoppa
+        'DIAM': 'DIAM',  # Diamond WM
+        'GTRI': 'GTRI',  # Diamond NW
+        'PBLT': 'PBLT',  # Preston
+    }, False),
+
 
     ('Viking Coaches', 'NW', {
         'VIKG': 'VIKG'
@@ -549,12 +541,11 @@ BOD_OPERATORS = [
     ('LNNE', 'NW', {}, False),
     ('NUTT', 'NW', {}, False),
     ('BLAC', 'NW', {}, False),
+    ('STOT', 'NW', {}, False),
+    ('IRVD', 'NW', {}, False),
 
     ('ROOS', 'SW', {}, False),
-    ('SEWR', 'SW', {}, False),
-    ('HRBT', 'SE', {}, False),
-    ('KENS', 'Y', {}, False),
-    ('AWAN', 'SE', {}, False),
+    ('SEWR', 'SW', {}, False),  
     ('LUCK', 'SW', {}, False),
 
     ('GVTR', 'NE', {}, False),
@@ -567,10 +558,18 @@ BOD_OPERATORS = [
     ('JOHS', 'WM', {}, False),
 
     ('ENSB', 'SE', {}, True),
+    ('AWAN', 'SE', {}, False),
+    ('HRBT', 'SE', {}, False),
+    ('CARL', 'SE', {}, False),
+    ('FALC', 'SE', {}, False),
+    ('VECT', 'SE', {}, True),
+    ('ACME', 'SE', {}, False),
+    # ('LTKR', 'SE', {}, False),
 
     ('BRYL', 'EM', {}, False),
     ('MDCL', 'EM', {}, False),
     ('NDTR', 'EM', {}, False),
+    ('COMM', 'EM', {}, False),
 
     ('RELD', 'Y', {}, False),
     ('SSSN', 'Y', {}, False),
@@ -579,6 +578,7 @@ BOD_OPERATORS = [
         'HCTY': 'HCTY',  # Connexions
         'YRRB': 'YRRB',  # 'Road Runner'
     }, False),
+    ('KENS', 'Y', {}, False),
 
     ('NCTP', None, {
         'NCTP': 'NCTP',  # CT Plus Bristol (/London)
@@ -593,18 +593,18 @@ BOD_OPERATORS = [
     ('SIMO', 'EA', {}, False),
     ('BEES', 'EA', {}, False),
     ('GOGO', 'NW', {}, False),
+    ('HATT', 'NW', {}, False),
+    ('FCHS', 'NW', {}, False),
     ('RBTS', 'EM', {}, False),
     ('DELA', 'EM', {}, False),
 
-    ('HATT', 'NW', {}, False),
     ('SULV', 'SE', {}, False),
     ('WBSV', 'SE', {}, False),
     ('REDE', 'SE', {}, False),
     ('GPLM', 'SE', {}, False),
     ('CLNB', 'SE', {}, False),
-
-    ('RCHC', 'SE', {}, False),
-    ('FCHS', 'NW', {}, False),
+    #('RCHC', 'SE', {}, False),
+    
     ('CRSS', 'WM', {}, True),  # NN Cresswell
     ('DAGC', None, {
         'DAGC': 'DAGC',
@@ -641,6 +641,9 @@ BOD_OPERATORS = [
         'THTR': 'THTR',
         'CSSO': 'CSSO',
     }, False),
+    ('East Yorkshire', 'Y', {
+        'EYMS': 'EYMS',
+    }, False),
 
     ('DRMC', 'WM', {}, True),
     ('SARG', 'WM', {}, False),
@@ -654,6 +657,9 @@ BOD_OPERATORS = [
         'RR': 'RDRT',
         'RR1': 'RDRT'
     }, False),
+    ('REDL', 'SE', {
+        'REDL': 'RLNE',
+    }, False),
 
     ('CUBU', 'NW', {}, False),
     ('HUYT', 'NW', {}, False),
@@ -661,7 +667,9 @@ BOD_OPERATORS = [
     ('PPBU', 'NW', {}, False),
     ('EAZI', 'NW', {}, False),
     ('MAGH', 'NW', {}, False),
+    ('WBTR', 'NW', {}, False),
     ('MAND', 'SE', {}, False),
+    ('RLNE', 'SE', {}, False),
     ('SOUT', 'SW', {}, False),
 ]
 

--- a/buses/settings.py
+++ b/buses/settings.py
@@ -295,6 +295,18 @@ PASSENGER_OPERATORS = [
        'RRTR': 'RRTR',
     }),
 
+    ('Transdev Blazefield', 'transdevblazefield', 'NW', {
+        'LUI': 'LNUD',
+        'ROS': 'ROST',
+        'BPT': 'BPTR',
+        'KDT': 'KDTR',
+        'HDT': 'HRGT',
+        'YCD': 'YCST',
+        'TPEN': 'TPEN',
+        'FLYE': 'FLYE',
+        'YACT': 'YACT',
+    }),
+
     # Reading
     ('Reading Buses', 'readingbuses', 'SE', {
         'RBUS': 'RBUS',

--- a/buses/settings.py
+++ b/buses/settings.py
@@ -279,21 +279,21 @@ PASSENGER_OPERATORS = [
         'MCG': 'MCGL',
         'McG': 'MCGL',
     }),
-    ('Warringtons Own Buses', 'warrington', 'NW', {
-        'WOB': 'WBTR',
-    }),
+    #('Warringtons Own Buses', 'warrington', 'NW', {
+    #    'WOB': 'WBTR',
+    #}),
     ('JMB Travel', 'jmbtravel', 'S', {
         'NJMT': 'NJMT',
     }),
     ('McColls Travel', 'mccolls', 'S', {
         'MCLS': 'MCLS',
     }),
-    ('Redline Buses', 'redline', 'SE', {
-        'REDL': 'RLNE',
-    }),
-    ('Red Rose Travel', 'redrose', 'SE', {
-        'RRTR': 'RRTR',
-    }),
+    #('Redline Buses', 'redline', 'SE', {
+    #    'REDL': 'RLNE',
+    #}),
+    #('Red Rose Travel', 'redrose', 'SE', {
+    #    'RRTR': 'RRTR',
+    #}),
 
     # Reading
     ('Reading Buses', 'readingbuses', 'SE', {
@@ -314,9 +314,9 @@ PASSENGER_OPERATORS = [
     # ('Go North East', 'gonortheast', 'NE', {
     #     'GNE': 'GNEL',
     # }),
-    ('East Yorkshire', 'eyms', 'Y', {
-        'EYMS': 'EYMS',
-    }),
+    #('East Yorkshire', 'eyms', 'Y', {
+    #    'EYMS': 'EYMS',
+    #}),
     # ('Go North West', 'gonorthwest', 'NW', {
     #     'GONW': 'GONW',
     # }),
@@ -409,7 +409,6 @@ BOD_OPERATORS = [
     ('HIPK', 'EM', {
         'OP': 'HIPK',
         'HPB': 'HIPK',
-    }, False),
     ('HNTS', 'EM', {}, False),
     # ('SLBS', 'WM', {}, True),
 
@@ -520,14 +519,14 @@ BOD_OPERATORS = [
         'OBUS': 'OBUS',
     }, False),
 
-    ('WNGS', None, {  # Rotala Group of Companies
-        'WINGS': 'WNGS',
-        'TGM': 'WNGS',  # Diamond SE
-        'NXHH': 'NXHH',  # Hotel Hoppa
-        'DIAM': 'DIAM',  # Diamond WM
-        'GTRI': 'GTRI',  # Diamond NW
-        'PBLT': 'PBLT',  # Preston
-    }, False),
+    #('WNGS', None, {  # Rotala Group of Companies
+    #    'WINGS': 'WNGS',
+    #    'TGM': 'WNGS',  # Diamond SE
+    #    'NXHH': 'NXHH',  # Hotel Hoppa
+    #    'DIAM': 'DIAM',  # Diamond WM
+    #    'GTRI': 'GTRI',  # Diamond NW
+    #    'PBLT': 'PBLT',  # Preston
+    #}, False),
 
     ('PLNG', 'EA', {}, False),
     ('SNDR', 'EA', {}, False),
@@ -718,6 +717,7 @@ TICKETER_OPERATORS = [
     ('NW', ['Finches', 'FCHS']),
     ('NW', ['GOGO'], 'Go Goodwins'),
     ('NW', ['BEVC'], 'Belle Vue'),
+    ('NW', ['WBTR'], 'Warringtons Own Buses'),
 
     ('SE', ['WBSV'], 'White Bus'),
     ('SE', ['REDE'], 'Red Eagle'),
@@ -728,6 +728,8 @@ TICKETER_OPERATORS = [
     ('SE', ['FALC'], 'Falcon Buses'),
     ('SE', ['Sullivan_Buses', 'SULV']),
     ('SE', ['ENSB'], 'Ensignbus'),
+    ('SE', ['RRTR'], 'Red Rose Travel'),
+    ('SE', ['Redline_Buses_Ltd', 'REDL']),
 
     ('SW', ['NTCP', 'NCTP'], 'HCT Group'),
 
@@ -762,10 +764,12 @@ TICKETER_OPERATORS = [
     ('SE', ['OXBC', 'CSLB', 'THTR'], 'Oxford Bus Company'),
     ('NW', ['GONW'], 'Go North West'),
     ('NE', ['GNEL'], 'Go North East'),
+    ('Y', ['EYMS'], 'East Yorkshire'),
     ('EA', ['GOEA', 'KCTB', 'HEDO', 'CHAM'], 'Go East Anglia'),
 
     # Rotala Operators
     ('WM', ['DIAM'], 'Diamond Bus'),
     ('NW', ['GTRI'], 'Diamond Bus North West'),
     ('NW', ['PBLT'], 'Preston Bus'),
+    {'SE', ['WNGS'], 'Diamond South East'),
 ]

--- a/buses/settings.py
+++ b/buses/settings.py
@@ -279,21 +279,21 @@ PASSENGER_OPERATORS = [
         'MCG': 'MCGL',
         'McG': 'MCGL',
     }),
-    #('Warringtons Own Buses', 'warrington', 'NW', {
-    #    'WOB': 'WBTR',
-    #}),
+    ('Warringtons Own Buses', 'warrington', 'NW', {
+       'WOB': 'WBTR',
+    }),
     ('JMB Travel', 'jmbtravel', 'S', {
         'NJMT': 'NJMT',
     }),
     ('McColls Travel', 'mccolls', 'S', {
         'MCLS': 'MCLS',
     }),
-    #('Redline Buses', 'redline', 'SE', {
-    #    'REDL': 'RLNE',
-    #}),
-    #('Red Rose Travel', 'redrose', 'SE', {
-    #    'RRTR': 'RRTR',
-    #}),
+    ('Redline Buses', 'redline', 'SE', {
+       'REDL': 'RLNE',
+    }),
+    ('Red Rose Travel', 'redrose', 'SE', {
+       'RRTR': 'RRTR',
+    }),
 
     # Reading
     ('Reading Buses', 'readingbuses', 'SE', {
@@ -314,9 +314,9 @@ PASSENGER_OPERATORS = [
     # ('Go North East', 'gonortheast', 'NE', {
     #     'GNE': 'GNEL',
     # }),
-    #('East Yorkshire', 'eyms', 'Y', {
-    #    'EYMS': 'EYMS',
-    #}),
+    ('East Yorkshire', 'eyms', 'Y', {
+       'EYMS': 'EYMS',
+    }),
     # ('Go North West', 'gonorthwest', 'NW', {
     #     'GONW': 'GONW',
     # }),
@@ -327,13 +327,11 @@ BOD_OPERATORS = [
     ('BEAT', 'NW', {}, False),
     ('APTC', 'SE', {}, False),
     ('FRNH', 'SE', {}, False),
-    ('HACO', 'EA', {}, False),
     ('SMMM', 'SE', {}, False),
     ('FWAY', 'SE', {}, False),
     ('JPCO', 'SW', {}, False),
     ('CACC', 'Y', {}, False),
     ('SWEY', 'Y', {}, False),
-    ('DEWS', 'EA', {}, False),
     ('WMSA', 'EM', {}, False),
     ('LANT', 'EM', {}, False),
     ('NWBT', 'NW', {}, False),
@@ -522,8 +520,17 @@ BOD_OPERATORS = [
     ('PLNG', 'EA', {}, False),
     ('SNDR', 'EA', {}, False),
     ('AWAY', 'EA', {}, False),
+    ('LYNX', 'EA', {}, False),
+    ('IPSW', 'EA', {}, False),
+    ('WNCT', 'EA', {}, False),
+    ('WHIP', 'EA', {}, False),
+    ('SIMO', 'EA', {}, False),
+    ('BEES', 'EA', {}, False),
+    ('HACO', 'EA', {}, False),
+    ('DEWS', 'EA', {}, False),
 
-    ('WNGS', None, {  # Rotala Group of Companies
+    # Rotala Group of Companies
+    ('WNGS', None, {
         'WINGS': 'WNGS',
         'TGM': 'WNGS',  # Diamond SE
         'NXHH': 'NXHH',  # Hotel Hoppa
@@ -531,7 +538,6 @@ BOD_OPERATORS = [
         'GTRI': 'GTRI',  # Diamond NW
         'PBLT': 'PBLT',  # Preston
     }, False),
-
 
     ('Viking Coaches', 'NW', {
         'VIKG': 'VIKG'
@@ -587,15 +593,6 @@ BOD_OPERATORS = [
         'CTPL': 'CTPL',  # CT Plus Yorkshire
     }, False),
 
-    ('LYNX', 'EA', {}, False),
-    ('IPSW', 'EA', {}, False),
-    ('WNCT', 'EA', {}, False),
-    ('WHIP', 'EA', {}, False),
-    ('SIMO', 'EA', {}, False),
-    ('BEES', 'EA', {}, False),
-    ('GOGO', 'NW', {}, False),
-    ('HATT', 'NW', {}, False),
-    ('FCHS', 'NW', {}, False),
     ('RBTS', 'EM', {}, False),
     ('DELA', 'EM', {}, False),
 
@@ -604,7 +601,7 @@ BOD_OPERATORS = [
     ('REDE', 'SE', {}, False),
     ('GPLM', 'SE', {}, False),
     ('CLNB', 'SE', {}, False),
-    #('RCHC', 'SE', {}, False),
+    ('RCHC', 'SE', {}, True),
     
     ('CRSS', 'WM', {}, True),  # NN Cresswell
     ('DAGC', None, {
@@ -642,9 +639,9 @@ BOD_OPERATORS = [
         'THTR': 'THTR',
         'CSSO': 'CSSO',
     }, False),
-    ('East Yorkshire', 'Y', {
-        'EYMS': 'EYMS',
-    }, False),
+    # ('East Yorkshire', 'Y', {
+    #     'EYMS': 'EYMS',
+    # }, False),
 
     ('DRMC', 'WM', {}, True),
     ('SARG', 'WM', {}, False),
@@ -658,19 +655,23 @@ BOD_OPERATORS = [
         'RR': 'RDRT',
         'RR1': 'RDRT'
     }, False),
-    ('REDL', 'SE', {
-        'REDL': 'RLNE',
-    }, False),
+    # ('REDL', 'SE', {
+    #     'REDL': 'RLNE',
+    # }, False),
 
+    ('GOGO', 'NW', {}, False),
+    ('HATT', 'NW', {}, False),
+    ('FCHS', 'NW', {}, False),
     ('CUBU', 'NW', {}, False),
     ('HUYT', 'NW', {}, False),
     ('AJTX', 'NW', {}, False),
     ('PPBU', 'NW', {}, False),
     ('EAZI', 'NW', {}, False),
     ('MAGH', 'NW', {}, False),
-    ('WBTR', 'NW', {}, False),
+    # ('WBTR', 'NW', {}, False),
+
     ('MAND', 'SE', {}, False),
-    ('RLNE', 'SE', {}, False),
+    # ('RLNE', 'SE', {}, False),
     ('SOUT', 'SW', {}, False),
 ]
 
@@ -737,7 +738,7 @@ TICKETER_OPERATORS = [
     ('SE', ['FALC'], 'Falcon Buses'),
     ('SE', ['Sullivan_Buses', 'SULV']),
     ('SE', ['ENSB'], 'Ensignbus'),
-    ('SE', ['RRTR'], 'Red Rose Travel'),
+    # ('SE', ['RRTR'], 'Red Rose Travel'),
     ('SE', ['Redline_Buses_Ltd', 'REDL']),
 
     ('SW', ['NTCP', 'NCTP'], 'HCT Group'),


### PR DESCRIPTION
Moved Diamond SouthEast to Ticketer instead of BODS
Removed Rotala ops from BODS as they are in Ticketer (Hotel Hoppa has no data via Ticketer nor BODS so it's a bit useless)
Moved East Yorkshire into Ticketer rather than Passenger
Moved Red Rose Travel into Ticketer rather than Passenger
Moved Warringtons Own Buses into Ticketer rather than Passenger
Moved Redline to Ticketer rather than Passenger