### PR TITLE
minor change to stop departure css

### DIFF
--- a/busstops/static/css/_base.scss
+++ b/busstops/static/css/_base.scss
@@ -1366,6 +1366,7 @@ input:not(:checked) + label {
 .aside td,
 .trip-timetable td {
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }
 
 #hugemap {


### PR DESCRIPTION
Sets nowrap for the route number text so that it doesn't fall onto a second line for 4+ digits

Before
![image](https://user-images.githubusercontent.com/25710026/171637637-21f059f3-d7f5-46af-8c57-ef59c066947a.png)

After
![image](https://user-images.githubusercontent.com/25710026/171637664-935c29c7-e895-4431-bccc-a4641e085629.png)
