### PR TITLE
Testing removing Diamond

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -453,12 +453,12 @@ YSTN:
     url: https://www.stationcoaches.co.uk/
 SPMW:
     url: https://www.stringerscoaches.co.uk/
-WNGS:
-    name: Diamond Bus South East
-    url: https://www.diamondbuses.com/south-east
-    twitter: DiamondBusSE
-    email: Comments-DiamondSE@rotala.co.uk
-    phone: 01784 425 621
+#WNGS:
+#    name: Diamond Bus South East
+#    url: https://www.diamondbuses.com/south-east
+#    twitter: DiamondBusSE
+#    email: Comments-DiamondSE@rotala.co.uk
+#    phone: 01784 425 621
 CTNY:
     name: Thames Valley Buses
     url: https://www.thamesvalleybuses.com/


### PR DESCRIPTION
Traveline NOC Database suggests is showing me that WNGS was updated on 1st June (and contact details are showing as the correct ones). and as such this could get removed. Just doing the # thing though until it refreshes to make sure.