### PR TITLE
STOT via Ticketer only

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -553,7 +553,7 @@ BOD_OPERATORS = [
     ('LNNE', 'NW', {}, False),
     ('NUTT', 'NW', {}, False),
     ('BLAC', 'NW', {}, False),
-    ('STOT', 'NW', {}, False),
+    #('STOT', 'NW', {}, False),
     ('IRVD', 'NW', {}, False),
 
     ('ROOS', 'SW', {}, False),


### PR DESCRIPTION
For some reason, BODS hasn't picked up the latest Stotts data. This is in the Ticketer feed though so temporarily I have just removed it from the normal BODS part (already exists in the Ticketer area)