### PR TITLE
Move L & G Coaches over to Ticketer feed

### DIFF
--- a/buses/settings.py
+++ b/buses/settings.py
@@ -831,6 +831,7 @@ TICKETER_OPERATORS = [
     ("EM", ["DELA"], "Delaine Buses"),
     ("NE", ["A-Line_Coaches_Tyne_&_Wear", "ALGC"]),
     ("NE", ["Coatham_Coaches", "COTY"]),
+    ("NE", ["L&G_Coaches", "LAGC"], "L & G Coaches"),
     ("NW", ["STOT"], "Stotts Tours"),
     ("NW", ["D&G_Bus_Ltd", "DAGC", "CRDR"]),
     ("NW", ["Finches", "FCHS"]),


### PR DESCRIPTION
This is so the vehicle tracking trips will match with the timetable correctly, as the current Traveline timetables have mismatching service numbers.