### PR TITLE
Arriva Merseyside Name

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -142,6 +142,7 @@ AFCL:
     name: Arriva Derby
     url: https://www.arrivabus.co.uk/derby
 AMSY:
+    name: Arriva Merseyside
     url: https://www.arrivabus.co.uk/north-west
 ANEA:
     name: Arriva North East


### PR DESCRIPTION
Currently AMSY and ANNW show up as Arriva North West which is very confusing.