### PR TITLE
Re-add mode to API trip operator info

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -140,7 +140,7 @@ class TripSerializer(serializers.ModelSerializer):
             return {
                 "noc": obj.operator_id,
                 "name": obj.operator.name,
-                # "vehicle_mode": obj.operator.vehicle_mode
+                "vehicle_mode": obj.operator.vehicle_mode
             }
 
     def get_times(self, obj):


### PR DESCRIPTION
Quite a few cases of service mode being blank, useful having operator mode as a fallback.