### PR TITLE
removal of JKHY/HDGS and edit to NYCC to reflect new unitary authority

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -149,10 +149,6 @@ GLOB:
     name: Globe Coaches (Wales)
 GLCS:
     name: Globe Holidays (Barnsley)
-HDGS:
-    name: Hodgsons Buses (County Durham)
-JKHY:
-    name: Hodgsons Buses (North Yorkshire)
 YCST:
     name: Transdev York
 TPEN:
@@ -414,3 +410,7 @@ ALTO:
 NMCO:
     url: https://www.nickmaddycoaches.co.uk/
     phone: 01981 240888
+NYCC:
+    name: North Yorkshire Council
+    url: https://www.northyorks.gov.uk/public-transport
+    twitter: northyorksc


### PR DESCRIPTION
JKHY was a legacy entry for Hodgsons no longer used, HDGS can now go back to its default name of "Hodgsons"
edited NYCC name, url and twitter to reflect the new unitary authority change