### PR TITLE
Update stops.yaml

### DIFF
--- a/fixtures/stops.yaml
+++ b/fixtures/stops.yaml
@@ -13,12 +13,6 @@
     bearing: NE
     latlong: POINT(1.0239 52.8685)
 
-# no longer called "Whipsnade Wild Anmal Park" or "ZSL Whipsnade Zoo"
-'021016052':
-    landmark: Whipsnade Zoo
-'021016053':
-    landmark: Whipsnade Zoo
-
 # clarify that "Walmer Castle" is a pub, not a castle (it's quite near Deal Castle)
 '2400A033500A':
     landmark: the Walmer Castle pub


### PR DESCRIPTION
These stops have been updated in NAPTAN. 

Stop 52 is in 'delete', stop '53' has no landmark in the database at all now but the common name refers to the zoo.