### PR TITLE
remove M92 reference from is_megabus

### DIFF
--- a/busstops/models.py
+++ b/busstops/models.py
@@ -801,7 +801,7 @@ class Service(models.Model):
 
     def is_megabus(self):
         return (
-            self.line_name in {"FAL", "TUBE", "M92"}
+            self.line_name in {"FAL", "TUBE"}
             or self.service_code == "PF0000459:197"  # X5
             or any(o.pk in {"MEGA", "SCMG", "SCLK"} for o in self.operator.all())
         )


### PR DESCRIPTION
To stop https://bustimes.org/services/m92-hillsborough-harley-2 showing megabus awin link. 
the proper M92 falls under `MEGA` anyway so is still caught