### PR TITLE
Central Connect

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -414,3 +414,6 @@ HRBT:
 COEV:
     name: Coach Events Services
     url: http://www.coacheventsservices.co.uk/
+GLLN:
+    url: https://localbus.vectare.co.uk/central-connect
+    twitter: VectareEssex


### PR DESCRIPTION
Updated Central Connect details (Op hasn't updated NOC and CC website and twitter has now gone with these being merged into Vectares main site/socials)