### PR TITLE
update operators.yaml (MESC as Bright Bus)

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -367,3 +367,7 @@ RMCB:
   url: https://ramsburyflyer.org/
 GHCT:
   url: https://gatesheadcentralbus.com/
+MESC:
+  name: Bright Bus
+  url: https://www.brightbustours.com/
+  twitter: BrightBusEDI


### PR DESCRIPTION
Bright Bus is under Eastern Scottish as MESC. I know this is more of a bandaid, but given they are both PM0000923 I can't imagine why this wouldn't work. Eastern Scottish as a brand name is dead, so it ought not to be on here.