### PR TITLE
Removes MESC as they now have normal service runs

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -352,9 +352,5 @@ RMCB:
   url: https://ramsburyflyer.org/
 GHCT:
   url: https://gatesheadcentralbus.com/
-MESC:
-  name: Bright Bus
-  url: https://www.brightbustours.com/
-  twitter: BrightBusEDI
 SUNB:
   twitter: ""


### PR DESCRIPTION
For some reason Edinburgh tenders have been put under MESC rather than MBLB.