### PR TITLE
Ignore Y20 folders on NI data

### DIFF
--- a/bustimes/management/commands/import_atco_cif.py
+++ b/bustimes/management/commands/import_atco_cif.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
 
         with zipfile.ZipFile(archive_name) as archive:
             for filename in archive.namelist():
-                if filename.endswith(".cif") and "/archive/" not in filename.lower():
+                if filename.endswith(".cif") and "/archive/" not in filename.lower() and "/Y20/" not in filename.upper():
                     with archive.open(filename) as open_file:
                         self.handle_file(open_file)
         assert self.stop_times == []


### PR DESCRIPTION
Y20 datasets are all dated from a long time ago and the data included in them either seems to be superseded.