### PR TITLE
Reduce edits chaos (Bee Network)

### DIFF
--- a/vehicles/management/commands/import_bod_avl.py
+++ b/vehicles/management/commands/import_bod_avl.py
@@ -155,6 +155,9 @@ class Command(ImportLiveVehiclesCommand):
             vehicles = self.vehicles.filter(
                 Q(operator__in=operators) | Q(operator=None)
             )
+        elif operator_ref == "BNML" or operator_ref == "BNSM":
+            defaults["livery_id"] = 1502
+            )
         elif not operators:
             vehicles = self.vehicles.filter(operator=None)
         elif len(operators) == 1:


### PR DESCRIPTION
Makes Bee Network Metroline and Stagecoach Manchester default to Bee Network livery. This should work the same as London but should help to reduce the amount of edits being done over the next few days.