### PR TITLE
White livery be default & if white livery and branding only show branding

### DIFF
--- a/vehicles/management/commands/import_bod_avl.py
+++ b/vehicles/management/commands/import_bod_avl.py
@@ -168,6 +168,7 @@ class Command(ImportLiveVehiclesCommand):
                 vehicles = self.vehicles.filter(operator=operator)
         else:
             defaults["operator"] = operators[0]
+            defaults["livery_id"] = 164
             vehicles = self.vehicles.filter(operator__in=operators)
 
         condition = Q(code__iexact=vehicle_ref)

--- a/vehicles/templates/vehicle_info.html
+++ b/vehicles/templates/vehicle_info.html
@@ -1,6 +1,6 @@
 {% if vehicle.colours or vehicle.livery %}
     <div class="livery" style="background:{{ vehicle.get_livery }}"></div>
-    {% if vehicle.livery and not (vehicle.livery_id == 164 and vehicle.branding) %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{{ vehicle.branding }}
+    {% if vehicle.livery %}{% if not vehicle.livery_id == 164 or not vehicle.branding %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{% endif %}{{ vehicle.branding }}
 {% endif %}
 
 {% if vehicle.notes %}

--- a/vehicles/templates/vehicle_info.html
+++ b/vehicles/templates/vehicle_info.html
@@ -1,6 +1,7 @@
 {% if vehicle.colours or vehicle.livery %}
     <div class="livery" style="background:{{ vehicle.get_livery }}"></div>
-    {% if vehicle.livery %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{{ vehicle.branding }}
+    {% if vehicle.livery_id == 164 %}{% if vehicle.branding %}{{ vehicle.branding }}{% else %}{{ vehicle.livery }}
+    {% elif vehicle.livery %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{{ vehicle.branding }}
 {% endif %}
 
 {% if vehicle.notes %}

--- a/vehicles/templates/vehicle_info.html
+++ b/vehicles/templates/vehicle_info.html
@@ -1,7 +1,6 @@
 {% if vehicle.colours or vehicle.livery %}
     <div class="livery" style="background:{{ vehicle.get_livery }}"></div>
-    {% if vehicle.livery_id == 164 %}{% if vehicle.branding %}{{ vehicle.branding }}{% else %}{{ vehicle.livery }}
-    {% elif vehicle.livery %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{{ vehicle.branding }}
+    {% if vehicle.livery and not (vehicle.livery_id == 164 and vehicle.branding) %}{{ vehicle.livery }}{% if vehicle.branding %}/{% endif %}{% endif %}{{ vehicle.branding }}
 {% endif %}
 
 {% if vehicle.notes %}


### PR DESCRIPTION
Seems to be the preferred way of working on Discord for ease for less experienced editors as well as still having the vehicle info page work the same as it did before white hex codes were added.