### PR TITLE
Stagecoach North Scotland Twitter

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -357,3 +357,6 @@ ELNV:
   url: https://ellenvale.co.uk/
 SBLB:
   name: Stagecoach North Scotland
+  twitter: |
+    StagecoachHLand
+    StagecoachBBird


### PR DESCRIPTION
Stagecoach North Scotland still uses both their respective Twitter accounts in the relevant areas.