### PR TITLE
Remove userid on approved/disproved for non trusted

### DIFF
--- a/vehicles/templates/vehicle_revision.html
+++ b/vehicles/templates/vehicle_revision.html
@@ -19,7 +19,7 @@
 
     {% if revision.disapproved or revision.approved_by_id %}
         <p><strong>{% if revision.disapproved %}Disa{% else %}A{% endif %}pproved</strong>
-            {% if revision.approved_by_id %}by <a href="{% url 'user_detail' revision.approved_by_id %}">user {{ revision.approved_by_id }}</a>{% if revision.disapproved_reason %}:{% endif %}{% endif %}
+            {% if revision.approved_by_id %}by {% if user.is_trusted %}<a href="{% url 'user_detail' revision.approved_by_id %}">user {{ revision.approved_by_id }}</a>{% else %}trusted user{% endif %}{% if revision.disapproved_reason %}:{% endif %}{% endif %}
             {% if revision.disapproved_reason %}{{ revision.disapproved_reason }}{% endif %}
     {% endif %}
 


### PR DESCRIPTION
As per Discord suggestion: https://discord.com/channels/981008654536966224/1336575686160285737

For approve/disprove, if a user is not trusted, it should show 'approved by trusted user' 
If a user is trusted though, it should show 'approved by user [id]'

This should help to reduce abuse towards approvers but still enable trusted users to report anyone abusing trusted permissions and tackle any issues with edits.