### PR TITLE
Hopefully picks up Flixbus London-Europe routes via Flixbus GTFS

### DIFF
--- a/bustimes/management/commands/import_gtfs_flixbus.py
+++ b/bustimes/management/commands/import_gtfs_flixbus.py
@@ -58,8 +58,8 @@ class Command(BaseCommand):
         feed = gtfs_kit.read_feed(path, dist_units="km")
 
         feed = feed.restrict_to_routes(
-            feed.routes[feed.routes.route_id.str.startswith("UK")].route_id
-            feed.routes[feed.routes.route_long_name.str.startswith("London")].route_long_name
+            feed.routes[feed.routes.route_id.str.startswith("UK")].route_id,
+            feed.routes[feed.routes.route_long_name.str.startswith("London")].route_long_name,
             feed.routes[feed.routes.route_long_name.str.endswith("London")].route_long_name
         )
 

--- a/bustimes/management/commands/import_gtfs_flixbus.py
+++ b/bustimes/management/commands/import_gtfs_flixbus.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         feed = feed.restrict_to_routes(
             feed.routes[feed.routes.route_id.str.startswith("UK")].route_id
             feed.routes[feed.routes.route_long_name.str.startswith("London")].route_long_name
-            feed.routes[feed.routes.route_long_name.str.endsswith("London")].route_long_name
+            feed.routes[feed.routes.route_long_name.str.endswith("London")].route_long_name
         )
 
         stops_data = {row.stop_id: row for row in feed.stops.itertuples()}

--- a/bustimes/management/commands/import_gtfs_flixbus.py
+++ b/bustimes/management/commands/import_gtfs_flixbus.py
@@ -57,11 +57,14 @@ class Command(BaseCommand):
 
         feed = gtfs_kit.read_feed(path, dist_units="km")
 
-        feed = feed.restrict_to_routes(
-            feed.routes[feed.routes.route_id.str.startswith("UK")].route_id,
-            feed.routes[feed.routes.route_long_name.str.startswith("London")].route_long_name,
-            feed.routes[feed.routes.route_long_name.str.endswith("London")].route_long_name
-        )
+
+        mask = (
+            feed.routes.route_id.str.startswith("UK") |
+            feed.routes.route_long_name.str.startswith("London") |
+            feed.routes.route_long_name.str.endswith("London")
+            )
+        feed = feed.restrict_to_routes(feed.routes[mask].route_id)
+        
 
         stops_data = {row.stop_id: row for row in feed.stops.itertuples()}
         stop_codes = {

--- a/bustimes/management/commands/import_gtfs_flixbus.py
+++ b/bustimes/management/commands/import_gtfs_flixbus.py
@@ -59,6 +59,8 @@ class Command(BaseCommand):
 
         feed = feed.restrict_to_routes(
             feed.routes[feed.routes.route_id.str.startswith("UK")].route_id
+            feed.routes[feed.routes.route_long_name.str.startswith("London")].route_long_name
+            feed.routes[feed.routes.route_long_name.str.endsswith("London")].route_long_name
         )
 
         stops_data = {row.stop_id: row for row in feed.stops.itertuples()}


### PR DESCRIPTION
Currently Flixbus London-Europe services come into Bustimes via BODs but the data is awful and becomes bugged when Flixbus GTFS refreshes. Hopefully this way London-Europe routes show up more accurate data and so the europe data doesn't bug out each week