### PR TITLE
Most Transdev links fixed

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -129,12 +129,6 @@ GLCS:
   name: Globe Holidays (Barnsley)
 TPEN:
   url: https://www.transdevbus.co.uk/team-pennine/
-HRGT:
-  url: https://www.transdevbus.co.uk/the-harrogate-bus-company/
-LNUD:
-  url: https://www.transdevbus.co.uk/the-blackburn-bus-company/
-BPTR:
-  url: https://www.transdevbus.co.uk/the-burnley-bus-company/
 FECS:
   name: First Eastern Counties
   twitter: |


### PR DESCRIPTION
Harrogate, Burnley and Blackburn links fixed in recent NOC update (https://github.com/bustimes/scrapings/commit/8fd1308aafb2b74f5f2c7481cc71527fd1df2fdd)

Team Pennine line still doesn't work though so I've kept that one.