### PR TITLE
Allow users to see their own pending and disapproved edits

### DIFF
--- a/vehicles/views.py
+++ b/vehicles/views.py
@@ -927,10 +927,9 @@ def vehicle_edits(request):
         request.GET or {"status": "approved"}, queryset=revisions
     )
     if request.user.is_anonymous or not (
-        request.user.trusted or request.user.is_superuser
-    ):
+        request.user.trusted or request.user.is_superuser or request.GET.get('user') == request.user.id
+    ) :
         f.filters["status"].field.choices = [("approved", "approved")]
-        # TODO: only show users' own disapproved edits
 
     if f.is_valid():
         paginator = Paginator(f.qs, 100)


### PR DESCRIPTION
This should allow users to select pending and disapproved from the status field.

I am unable to test it, but as long as I have the correct way of getting the user IDs, the logic expression should hopefully work. Unless of course I am missing anything?