### PR TITLE
Fix to actually allow users to see their own disapproved edits

### DIFF
--- a/vehicles/views.py
+++ b/vehicles/views.py
@@ -932,7 +932,7 @@ def vehicle_edits(request):
     if request.user.is_anonymous or not (
         request.user.trusted
         or request.user.is_superuser
-        or request.GET.get("user") == request.user.id
+        or request.GET.get("user") == str(request.user.id)
     ):
         f.filters["status"].field.choices = [("approved", "approved")]
 


### PR DESCRIPTION
In my previous commit I forgot that Python is type sensitive when making comparisons - since one was a string and the other was an integer it would always return False and not work. This commit fixes that, and I have now managed to test this in a local instance