### PR TITLE
Reducing username length to 50 chars

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -67,7 +67,10 @@ class LoginForm(AuthenticationForm):
 
 class UserForm(Form):
     name = CharField(
-        required=False, label="Username", validators=[UnicodeUsernameValidator()]
+        required=False,
+        label="Username",
+        validators=[UnicodeUsernameValidator()],
+        max_length=50,
     )
 
     def __init__(self, data, *args, user, **kwargs):

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -151,6 +151,16 @@ class RegistrationTest(TransactionTestCase):
         other_user.refresh_from_db()
         self.assertEqual(other_user.username, "kenton_schweppes")
 
+        # try setting a looong username:
+        response = self.client.post(
+            other_user.get_absolute_url(),
+            {"name": "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr."},
+        )
+        self.assertContains(
+            response, ">Ensure this value has at most 50 characters (it has 53).</"
+        )
+
+        # try copying someone else's username
         response = self.client.post(other_user.get_absolute_url(), {"name": "josh"})
         self.assertContains(
             response, '<ul class="errorlist"><li>Username taken</li></ul>'


### PR DESCRIPTION
Unless someones username is just full stops, 150 characters doesnt fit onto almost any screen. 50 characters should be more than enough so that usernames aren't needlessly much wider than the screen but should also be enough that people are happy with their usernames.

Discord Bug report: https://discord.com/channels/981008654536966224/1299411686503088200