### PR TITLE
Internal titles for situations

### DIFF
--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -8,12 +8,11 @@
         {% if situation.summary and not situation.summary.startswith("hide:") %}
             <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
             <summary>
-                  {{ situation.summary }}
-                  {% for validity_period in situation.list_validity_periods %}
-                      <div class="dates">{{ validity_period }}</div>
-                  {% endfor %}
-             </summary>
-        {% endif %}
+                {{ situation.summary }}
+                {% for validity_period in situation.list_validity_periods %}
+                    <div class="dates">{{ validity_period }}</div>
+                {% endfor %}
+            </summary>
         {% else %}<div class="situation">{% endif %}
 
         {% if situation.text %}

--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -5,7 +5,7 @@
 {% for situation in situations %}
     {% if situation.summary != 'Does not stop here' %}
 
-        {% if situation.summary and not situation.summary.startswith("hide:") %}
+        {% if situation.summary and not situation.summary.[:5] =="hide:" %}
             <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
             <summary>
                 {{ situation.summary }}

--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -5,16 +5,15 @@
 {% for situation in situations %}
     {% if situation.summary != 'Does not stop here' %}
 
-        {% if situation.summary %}
-            {% if not situation.summary.startswith("hide:") %}
-                <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
-                <summary>
-                    {{ situation.summary }}
-                    {% for validity_period in situation.list_validity_periods %}
-                        <div class="dates">{{ validity_period }}</div>
-                    {% endfor %}
-                </summary>
-            {% endif %}
+        {% if situation.summary and not situation.summary.startswith("hide:") %}
+            <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
+            <summary>
+                  {{ situation.summary }}
+                  {% for validity_period in situation.list_validity_periods %}
+                      <div class="dates">{{ validity_period }}</div>
+                  {% endfor %}
+             </summary>
+        {% endif %}
         {% else %}<div class="situation">{% endif %}
 
         {% if situation.text %}

--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -6,7 +6,7 @@
     {% if situation.summary != 'Does not stop here' %}
 
         {% if situation.summary %}
-            {% if not situation.summary.startswith("[hide]") %}
+            {% if not situation.summary.startswith("hide:") %}
                 <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
                 <summary>
                     {{ situation.summary }}

--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -5,7 +5,7 @@
 {% for situation in situations %}
     {% if situation.summary != 'Does not stop here' %}
 
-        {% if situation.summary and not situation.summary.[:5] =="hide:" %}
+        {% if situation.summary and not situation.summary[:5] =="hide:" %}
             <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
             <summary>
                 {{ situation.summary }}

--- a/busstops/templates/situations.html
+++ b/busstops/templates/situations.html
@@ -6,13 +6,15 @@
     {% if situation.summary != 'Does not stop here' %}
 
         {% if situation.summary %}
-            <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
-            <summary>
-                {{ situation.summary }}
-                {% for validity_period in situation.list_validity_periods %}
-                    <div class="dates">{{ validity_period }}</div>
-                {% endfor %}
-            </summary>
+            {% if not situation.summary.startswith("[hide]") %}
+                <details class="situation"{% if forloop.first and forloop.last and situation.text|length < 100 %} open{% endif %}>
+                <summary>
+                    {{ situation.summary }}
+                    {% for validity_period in situation.list_validity_periods %}
+                        <div class="dates">{{ validity_period }}</div>
+                    {% endfor %}
+                </summary>
+            {% endif %}
         {% else %}<div class="situation">{% endif %}
 
         {% if situation.text %}


### PR DESCRIPTION
To save dealing with 'Situation object (id)' which is really annoying, hopefully this commit lets me add [hide] to a situation title and then it won't display the situation summary or validity period. Perfect for some of the situation which need titles so we can keep things tidier, but we don't want the title public.

(I've not changed as much as this is suggesting. I've added line 9 and 17, the rest I have tabbed over 1 space).