### PR TITLE
Fix A2B's twitter

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -360,3 +360,5 @@ FLON:
 HOWT:
   name: Omega Busways
   url: https://www.omegabusways.uk/
+A2BR:
+  twitter: a2btravelgroup


### PR DESCRIPTION
The [@A2bbusandcoach](https://x.com/A2bbusandcoach) twitter account no longer exists. They use [@a2btravelgroup](https://x.com/a2btravelgroup) now.

This PR updates the `operators.yml` file to manually correct their Twitter.