### PR TITLE
Ashwood Travel

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -375,3 +375,5 @@ ACAH:
   name: Aircoach
 KLCO:
   url: https://klch.co.uk/
+NTMY:
+  name: Ashwood Travel


### PR DESCRIPTION
Not sure on the story but Ashwood are using this NOC code despite it being allocated to an old O licence holder in Scotland. Just doing this incase the admin panel doesn't save my temp override.