### PR TITLE
Updates operator_vehicles view to make it more user friendly

### DIFF
--- a/vehicles/templates/operator_vehicles.html
+++ b/vehicles/templates/operator_vehicles.html
@@ -31,7 +31,7 @@
             <li><a href="{{ object.get_absolute_url }}/map">Map</a></li>
         {% endif %}
         {% if tickets_link %}
-        <li><a href="{{ tickets_link }}">Tickets</a></li>
+            <li><a href="{{ tickets_link }}">Tickets</a></li>
         {% endif %}
         <li>{{ vehicles|length }} vehicle{{ vehicles|length|pluralize }}</li>
     </ul>


### PR DESCRIPTION
Currently when clicking from 'routes' to 'vehicles' the page jumps higher because there is no 'a [mode] operator in [region]' so I have added that in so the page doesn't jump when going between vehicle and routes view.

Also added 'tickets' link to Vehicles page where tickets link exists. Currently this is a bit messy as you can only access the 'tickets' page if you are on the 'routes' page and can't access it from the vehicles page.