### PR TITLE
Update Ember GTFS URL to latest static file

### DIFF
--- a/bustimes/management/commands/import_gtfs_ember.py
+++ b/bustimes/management/commands/import_gtfs_ember.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         path = settings.DATA_DIR / Path("ember_gtfs.zip")
 
         source = DataSource.objects.get(name="Ember")
-        source.url = "https://api.ember.to/v1/gtfs/static/"
+        source.url = "https://cdn.ember.to/gtfs/static/Ember_GTFS_latest.zip"
 
         modified, last_modified = download_if_modified(path, source)
         assert modified


### PR DESCRIPTION
Ember's GTFS static URL is changing, with the static file now served by a CDN rather than via API. The realtime URL remains unchanged.