### PR TITLE
Op Fixtures

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -244,9 +244,6 @@ HOWT:
   url: https://www.omegabusways.uk/
 SSSN:
   url: https://www.shorelinetravel.co.uk/
-LCCO: #NOC deleted, data should soon move to Evolve
-  name: South Derbyshire Coaches
-  url: http://www.southderby.com/
 WEFC:
   url: https://www.westmorlandandfurness.gov.uk/parking-streets-and-transport/bus-services/find-bus
 ACAH:
@@ -279,3 +276,7 @@ DGCB:
   url: https://www.dumfriesandgalloway.gov.uk/roads-transport-parking/public-transport/bus-ferry-timetables
 YSQU:
   url: https://www.squarepegbuses.co.uk/
+GOCH:
+  name: Go Bus
+KNCO:
+  url: https://kentcountrybuses.co.uk/


### PR DESCRIPTION
Removed LCCO as operator has rebranded to Evolve.
Added GoCoach override to Go Bus their new trading name Added KNCO website