### PR TITLE
Making service debug clearer

### DIFF
--- a/bustimes/templates/service_debug.html
+++ b/bustimes/templates/service_debug.html
@@ -49,8 +49,8 @@
         <br>RevisionNumber: {{ route.revision_number }}
         <br>OperatingPeriod: {{ route.start_date }}–{{ route.end_date }}
         <br>PublicUse: {{ route.public_use }}
-        <br>{{ route.description }}
-        <br>{{ route.origin }} to {{ route.destination }} via {{ route.via }}
+        <br>RouteDescription: {{ route.description }}
+        <br>StandardService: {{ route.origin }} to {{ route.destination }} via {{ route.via }}
 
         <br><a href="{% url 'admin:bustimes_route_change' route.id %}">Edit</a>
     </summary>


### PR DESCRIPTION
Just adding small bits of text to make it simpler to know which descriptions are which on the route debug page