### PR TITLE
Drop Python line_name pre-sort where DB collation now suffices

### DIFF
--- a/busstops/models.py
+++ b/busstops/models.py
@@ -548,7 +548,7 @@ class StopPoint(models.Model):
                 return parts[-1]
 
     def get_line_names(self):
-        return sorted(filter(None, self.line_names), key=Service.get_line_name_order)
+        return list(filter(None, self.line_names))
 
 
 class OperatorGroup(models.Model):

--- a/busstops/views.py
+++ b/busstops/views.py
@@ -742,7 +742,9 @@ def get_departures_context(stop, services, form_data, stops=None) -> dict:
     return context
 
 
-stop_line_names = ArrayAgg("stopusage__line_name", distinct=True, default=None)
+stop_line_names = ArrayAgg(
+    "stopusage__line_name", distinct=True, ordering="stopusage__line_name", default=None
+)
 operator_names = ArrayAgg("operator__name", distinct=True, default=None)
 
 


### PR DESCRIPTION
## Summary

Two weeks ago we added the `en_numeric` ICU collation (locale `en-u-kn-true`, deterministic=False) and applied it to `StopUsage.line_name` and `Route.line_name`. This PR removes the now-redundant Python sort for data sourced from `StopUsage.line_name`.

## Changes

**`busstops/views.py`** — `stop_line_names` ArrayAgg gains an `ordering` argument so the database sorts the aggregated line names using the ICU collation:

```python
# before
stop_line_names = ArrayAgg("stopusage__line_name", distinct=True, default=None)

# after
stop_line_names = ArrayAgg(
    "stopusage__line_name", distinct=True, ordering="stopusage__line_name", default=None
)
```

**`busstops/models.py`** — `StopPoint.get_line_names()` no longer re-sorts the annotated array in Python:

```python
# before
return sorted(filter(None, self.line_names), key=Service.get_line_name_order)

# after
return list(filter(None, self.line_names))
```

## What's unchanged

- `Service.line_name` has no ICU collation (there is a `line_name__regex=...` lookup that requires a deterministic collation). All call sites that sort data derived from `Service.line_name` are untouched:
  - `Service.get_line_names()` / `Service.get_order()` in `busstops/models.py`
  - Choice sorting in `busstops/forms.py`
  - Service list sorting via `Service.get_order` in `busstops/models.py` (the related-services query)
- `get_line_name_order` itself is kept — it is still used for `Service.line_name` paths.

## Known trade-off

The X/N prefix special-case in `get_line_name_order` (which sorted "N8" / "X10" after plain numeric routes) is intentionally lost for `StopUsage`-sourced line names. The ICU numeric collation sorts them lexicographically by prefix instead. This trade-off was accepted when the collation was added.

## Tests

Note: the remote execution environment has no running PostgreSQL and PyPI access is blocked, so `./manage.py test busstops bustimes` could not be run here. The changes are minimal (2 lines changed) and mechanically follow from the collation migration. Please run the test suite locally before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vko3K4kNkgbCMCfV1PPhaz)_