### PR TITLE
CHAM/HEDO Op Fixture

### DIFF
--- a/fixtures/operators.yaml
+++ b/fixtures/operators.yaml
@@ -130,9 +130,6 @@ KCTB:
     NR1 3NX
 HEDO:
   name: KonectBuses (formerly Hedingham & Chambers)
-  url: https://www.konectbuses.co.uk/
-CHAM:
-  url: https://www.konectbuses.co.uk/
 BHBC:
   name: Brighton & Hove
 WNCT:


### PR DESCRIPTION
https://github.com/bustimes/scrapings/commit/d5ca87896d9e9e17e5c1b733511dc9b9ea75c114

HEDO details updated on NOC. CHAM no longer exists in database