### PR TITLE
Refactor journey details by removing date div

### DIFF
--- a/frontend/js/BigMap.tsx
+++ b/frontend/js/BigMap.tsx
@@ -504,6 +504,9 @@ function JourneySidebar(props: {
           ) : null}
         </div>
       ) : null}
+      <p className="journey-datetime">
+        {journey.date} {journey.datetime.slice(11, 16)} to {journey.destination}
+      </p>
       {!journey.trip && journey.destination ? (
         <p>To {journey.destination}</p>
       ) : null}
@@ -539,10 +542,6 @@ function JourneySidebar(props: {
             </dd>
           </div>
         ) : null}
-        <div>
-          <dt>Date</dt>
-          <dd>{journey.date}</dd>
-        </div>
       </dl>
     </div>
   );


### PR DESCRIPTION
Added a new p tag just below the navigation to show the date, datetime and destination.  Should hopefully make it easier to see which journey the current trip is on.